### PR TITLE
feat(init): add flag group for git directory and working tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ Outputs list of either available hooks or supported languages.
 Opens your browser with Git documentation for the specified git hook, helping you understand its usage.
 
 ## Future TODOs
-- [ ] add either flags or subcommand for init to specify dir and worktree; also if you want the hkup folder to be hidden or not
-- [ ] functionality to save custom setups (ie gitdir and workdir are not in same location)
 - [ ] make an update subcommand
 - [ ] store custom git hooks as templates for future use (via add template subcmd)
     - Allow users to create, store, and share templates for common hooks. Users can fetch these templates over the network.

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -16,5 +16,8 @@ var (
 )
 
 func init() {
+	initCmd.Flags().StringVar(&logic.GitDir, "gitdir", "", "specified path to git directory")
+	initCmd.Flags().StringVar(&logic.WorkTree, "worktree", "", "specified path to working tree")
+	initCmd.MarkFlagsRequiredTogether("gitdir", "worktree")
 	rootCmd.AddCommand(initCmd)
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -30,7 +30,7 @@ func TestInitCmd(t *testing.T) {
 	}{
 		{
 			args: []string{"init"},
-			want: "Usage:\n  hkup init [flags]\n\nFlags:\n  -h, --help   help for init\n\n",
+			want: "Usage:\n  hkup init [flags]\n\nFlags:\n      --gitdir string     specified path to git directory\n  -h, --help              help for init\n      --worktree string   specified path to working tree\n\n",
 			err:  fmt.Errorf("hooksPath already set to .hkup\n"),
 		},
 		// Add more test cases here if necessary, e.g., for error conditions

--- a/internal/logic/add.go
+++ b/internal/logic/add.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	// Lang is a flag indicating the programming language to use for the hook script. Defaults to sh.
+	// Lang is an optional flag indicating the programming language to use for the hook script. Defaults to sh.
 	Lang string
 )
 

--- a/internal/logic/init.go
+++ b/internal/logic/init.go
@@ -10,22 +10,40 @@ import (
 )
 
 var (
-	// FullPath defines the local repository folder name to hold Git hooks via a relative path.
-	// It is treated as a constant and points to the ".hkup" directory within the current working directory.
+	// FullPath defines the local repository folder name to hold Git hooks via a
+	// relative path.
+	// It is treated as a constant and points to the ".hkup" directory within the
+	// current working directory.
 	FullPath = filepath.Join(".", ".hkup")
+
+	// gitCmd defines the terminal command to use to initialize the hkup folder.
+	gitCmd = []string{"config", "--local", "core.hooksPath", FullPath}
+
+	// GitDir is an optional flag that defines the location of the git directory.
+	// Can be useful for bare repos or custom git setups where git directory and
+	// working directory are not in the same location.
+	GitDir string
+
+	// WorkTree is an optional flag that defines the location of the working tree
+	// of a local git repository.
+	WorkTree string
 )
 
 // Init initializes the hkup folder for storing Git hooks in the current repository.
-// It checks if the current working directory is a Git repository, creates the hkup folder if it doesn't exist,
-// and sets the Git configuration for `core.hooksPath` to point to the hkup folder.
-// Returns an error if the current directory is not a Git repository, if the folder creation fails,
-// or if there is an issue setting the Git hooks path.
+// It checks if there the git directory and worktree flags are provided.
+// Else it will check if the current working directory is a Git repository, creates
+// the hkup folder if it doesn't exist, and sets the Git configuration for
+// `core.hooksPath` to point to the hkup folder.
+// Returns an error if the current directory is not a Git repository, if the folder
+// creation fails, or if there is an issue setting the Git hooks path.
 //
 // Returns:
 // - error: Returns an error if any of the steps fail; otherwise, it returns nil.
 func Init(cmd *cobra.Command, args []string) error {
-	if err := exec.Command("git", "-C", ".", "rev-parse", "--is-inside-work-tree").Run(); err != nil {
-		return fmt.Errorf("failed to check if cwd is git repo: %w", err)
+	if GitDir != "" && WorkTree != "" {
+		gitCmd = []string{"--git-dir=" + GitDir, "--work-tree=" + WorkTree, "config", "--local", "core.hooksPath", FullPath}
+	} else if err := exec.Command("git", "-C", ".", "rev-parse", "--is-inside-work-tree").Run(); err != nil {
+		return fmt.Errorf("failed to check if current working directory is git repo: %w", err)
 	}
 
 	if !util.DoesDirectoryExist(FullPath) {
@@ -38,7 +56,7 @@ func Init(cmd *cobra.Command, args []string) error {
 	if out, _ := exec.Command("git", "config", "--local", "core.hooksPath").Output(); len(out) != 0 {
 		return fmt.Errorf("hooksPath already set to %s", out)
 	} else {
-		if err := exec.Command("git", "config", "--local", "core.hooksPath", FullPath).Run(); err != nil {
+		if err := exec.Command("git", gitCmd...).Run(); err != nil {
 			return fmt.Errorf("failed to set hooksPath: %w", err)
 		}
 		return nil


### PR DESCRIPTION
- added optional flag group of '--gitdir' and '--worktree'
    - Ability to specify the path to the git directory and working tree.

Note that since a flag group must be used together or results in error.