### PR TITLE
feat: improve list subcommand

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -6,10 +6,19 @@ import (
 )
 
 var listCmd = &cobra.Command{
-	Use:       "list {hook|lang}",
-	Short:     "List git hooks information",
-	ValidArgs: []string{"hook", "lang"},
-	Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	Use:   "list [hook|lang|template]",
+	Short: "List git hooks information",
+	Long: `List git hooks information for the specified category.
+
+If no arguments are provided, this command will display the hooks used
+in the current working directory.
+
+Valid arguments:
+- hook:     Displays supported git hooks.
+- lang:     Displays supported languages used for hooks.
+- template: Displays user-defined templates.`,
+	ValidArgs: []string{"hook", "lang", "template"},
+	Args:      cobra.MatchAll(cobra.MaximumNArgs(1), cobra.OnlyValidArgs),
 	RunE:      logic.List,
 }
 

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -30,11 +30,6 @@ func TestListCmd(t *testing.T) {
 		err  error
 	}{
 		{
-			args: []string{"list"},
-			want: "",
-			err:  fmt.Errorf("accepts 1 arg(s), received 0"),
-		},
-		{
 			args: []string{"list", "test"},
 			want: "",
 			err:  fmt.Errorf("invalid argument \"test\" for \"hkup list\""),

--- a/internal/logic/init.go
+++ b/internal/logic/init.go
@@ -42,7 +42,7 @@ func Init(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("must run \"hkup init\" inside a worktree")
 	}
 
-	var gitCmd []string    // Holds everything after the root git command
+	gitCmd := []string{}   // Holds everything after the root git command
 	var hkupDirPath string // Holds the path the .hkup directory
 
 	// If both flags are set, configure core.hooksPath with their values.

--- a/internal/logic/list.go
+++ b/internal/logic/list.go
@@ -1,30 +1,88 @@
 package logic
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/iton0/hkup-cli/internal/git"
 	"github.com/iton0/hkup-cli/internal/util"
 	"github.com/spf13/cobra"
 )
 
-// List displays a list of available Git hooks or supported languages based on
-// the provided argument.
+// List displays a list of one of the below based on provided arguement:
+//   - Supported git hooks
+//   - Supported languages
+//   - User-defined git hook templates
+//   - Git hook(s) used in the current working directory
 //
-// Returns error if the argument is invalid.
+// Returns error if issue with checking directories.
 func List(cmd *cobra.Command, args []string) error {
-	arg := args[0]
 	out := []string{}
 
-	// NOTE: Default case is handled by cobra framework
-	switch {
-	case arg == "hook":
-		out = util.ConvertMapKeysToSlice(git.Hooks())
-	case arg == "lang":
-		out = util.ConvertMapKeysToSlice(git.SupportedLangs())
+	if len(args) > 0 { // Gets appropriate output based on argument provided
+		switch args[0] {
+		case "template":
+			out = getHookTemplates()
+			if out == nil {
+				return fmt.Errorf("could not read template directory")
+			}
+		case "hook":
+			out = util.ConvertMapKeysToSlice(git.Hooks())
+		case "lang":
+			out = util.ConvertMapKeysToSlice(git.SupportedLangs())
+		}
+	} else { // No args; gets hooks in current working directory
+		out = getCwdHooks()
+		if out == nil {
+			return fmt.Errorf("could not read .hkup directory")
+		}
 	}
 
-	for _, key := range out {
-		cmd.Printf(" %s\n", key)
-	}
-
+	cmd.Print(formatOutput(out))
 	return nil
+}
+
+// formatOutput formats the output string slice as a string that is returned
+func formatOutput(out []string) string {
+	var fout string
+
+	for _, val := range out {
+		fout += " " + val + "\n"
+	}
+
+	return fout
+}
+
+// getHookTemplates returns all user-defined templates.
+// If no templates are found, returns a empty string slice.
+func getHookTemplates() []string {
+	out := []string{}
+
+	files, err := os.ReadDir(util.GetTemplateDirPath())
+	if err != nil {
+		return nil
+	}
+
+	for _, file := range files {
+		out = append(out, file.Name())
+	}
+
+	return out
+}
+
+// getCwdHooks returns the hooks in the current working directory.
+// If no hooks are found, returns a empty string slice.
+func getCwdHooks() []string {
+	out := []string{}
+
+	files, err := os.ReadDir(util.HkupDirName)
+	if err != nil {
+		return nil
+	}
+
+	for _, file := range files {
+		out = append(out, file.Name())
+	}
+
+	return out
 }


### PR DESCRIPTION
- added no arg option which outputs git hooks in the current working
  directory via `hkup list`
- added 'template' arg to list all user-defined templates
- updated help page based on the changes above
