### PR TITLE
fix(internal/logic/root): resolve gh command issue

### DIFF
--- a/internal/logic/root.go
+++ b/internal/logic/root.go
@@ -14,13 +14,26 @@ import (
 // Returns error if issue with cloning repository or initializing HkUp.
 func Root(cmd *cobra.Command, args []string) error {
 	// Tries to run git command in the terminal
-	err := util.RunCommandInTerminal(args[0], args[1:]...)
-	if err != nil {
+	if err := util.RunCommandInTerminal(args[0], args[1:]...); err != nil {
 		return err
 	}
 
+	possibleRepoUrl := args[len(args)-2]
+	possibleCustomDir := args[len(args)-1]
+
+	// Loop through the args to see if "--" is used.
+	// Gets the two previous args and sets them to the repoUrl and
+	// possibleCustomDir variables, respectively.
+	for i, v := range args {
+		if v == "--" {
+			possibleRepoUrl = args[i-2]
+			possibleCustomDir = args[i-1]
+			break
+		}
+	}
+
 	// Tries to cd into the created directory
-	if err = cdLogic(args[len(args)-2], args[len(args)-1]); err != nil {
+	if err := cdLogic(possibleRepoUrl, possibleCustomDir); err != nil {
 		return err
 	}
 
@@ -28,26 +41,39 @@ func Root(cmd *cobra.Command, args []string) error {
 	return Init(cmd, nil)
 }
 
-// cdLogic implements the HkUp wrapper logic around git-related clone command.
+// cdLogic implements the HkUp wrapper logic around cloning for both 'git' and
+// 'gh' command.
 // Returns error if issue with changing directory
-func cdLogic(secondLast, dir string) error {
-	// Using the regular 'git' command
-	if strings.HasSuffix(dir, ".git") { // bare
-		start := strings.LastIndex(dir, "/") + 1
-		dir = dir[start:]
+func cdLogic(possibleRepoUrl, possibleCustomDir string) error {
+	// No custom directory name provided when using git command
+	usedDefaultGit := strings.HasSuffix(possibleCustomDir, ".git")
 
-		// If the repo is not bare then updates the directory name ie regular clone
-		if isBare, err := isBareRepo(dir); err != nil || !isBare {
-			end := strings.LastIndex(dir, ".git")
-			dir = dir[start:end]
+	// No custom directory name provided when using gh command
+	usedDefaultGh := strings.Count(possibleRepoUrl, "/") != 1 && !usedDefaultGit
+
+	// Starting index of the remote repo name
+	start := strings.LastIndex(possibleCustomDir, "/") + 1
+
+	// Checks if user did not provide a custom directory name
+	if usedDefaultGit { // git command
+		// If the repo is bare then just take the remote repo name
+		if isBare, _ := isBareRepo(possibleCustomDir[start:]); isBare {
+			possibleCustomDir = possibleCustomDir[start:]
+		} else { // Repo is not bare ie regular clone
+			end := strings.LastIndex(possibleCustomDir, ".git")
+			possibleCustomDir = possibleCustomDir[start:end]
 		}
-	} else if strings.Count(secondLast, "/") != 1 { // When using Github CLI
-		start := strings.LastIndex(dir, "/") + 1
-		dir = dir[start:]
+	} else if usedDefaultGh { // gh command
+		// If the repo is bare then just take the remote repo name
+		if isBare, _ := isBareRepo(possibleCustomDir[start:] + ".git"); isBare {
+			possibleCustomDir = possibleCustomDir[start:] + ".git"
+		} else { // Repo is not bare ie regular clone
+			possibleCustomDir = possibleCustomDir[start:]
+		}
 	}
 
 	// Either successful or returns error if issue with changing directory
-	return os.Chdir(dir)
+	return os.Chdir(possibleCustomDir)
 }
 
 // isBareRepo reports if given directory (dir) is a bare git repository.


### PR DESCRIPTION
- updated cdLogic function to properly handle use of gh command
- updated main Root function to check specifically for flags when gh
  command is used

This commit should make the `hkup --` functionality more robust to user
args for both git and gh commands. For example this should work when
running `gh repo clone <url> [<customdir>] -- --bare`.

